### PR TITLE
Adds EXPERIMENTAL iNav Support for Rate Conversion

### DIFF
--- a/backend/app/multirotor_rate_converter/__init__.py
+++ b/backend/app/multirotor_rate_converter/__init__.py
@@ -138,4 +138,27 @@ fc_firmware_constants = {
             },
         },
     },
+    "inavflight": {
+        "id": "5",
+        "label": "iNavFlight",
+        "backgroundColor": "rgb(245, 255, 61)",
+        "borderColor": "rgb(245, 255, 61)",
+        "rateValues": {
+            "rc_rate": {"title": "Unused", "step": 1, "min": 0, "max": 1, "default": 1},
+            "rate": {
+                "title": "Max Rate",
+                "step": 1,
+                "min": 0,
+                "max": 1000,
+                "default": 670,
+            },
+            "rc_expo": {
+                "title": "Expo",
+                "step": 1,
+                "min": 0,
+                "max": 100,
+                "default": 70,
+            },
+        },
+    },
 }

--- a/frontend/public/js/gradientDescentWorker.js
+++ b/frontend/public/js/gradientDescentWorker.js
@@ -301,7 +301,7 @@ function gradientDescent(srcRateType, tgtRateType, srcRates){
     });
 
     let formatted_rate, formatted_rc_rate, formatted_rc_expo;
-    if (tgtRateType === "raceflight") {
+    if (tgtRateType === "raceflight" || tgtRateType === "inavflight") {
         formatted_rate = Math.ceil(rate);
         formatted_rc_rate = Math.ceil(rcRate);
         formatted_rc_expo = Math.ceil(rcExpo);

--- a/frontend/public/js/main.js
+++ b/frontend/public/js/main.js
@@ -6,9 +6,6 @@ window.addEventListener('load', () => {
 
 function init(){
 
-    generateRateTableGroup()
-    generateRateTableGroup('actual')
-
     // defaults: 
     //   - server api calculation
     //   - legacy ui
@@ -19,6 +16,41 @@ function init(){
 
     const urlParams = new URLSearchParams(window.location.search);
     
+    if (urlParams.get('inav') == 1) {
+        rateDetails["inavflight"] = {
+            "id": "5",
+            "label": "iNavFlight",
+            "backgroundColor": "rgb(245, 255, 61)",
+            "borderColor": "rgb(245, 255, 61)",
+            "rateValues": {
+                "rc_rate": {
+                    "title": "Unused",
+                    "step": 1,
+                    "min": 0,
+                    "max": 1,
+                    "default": 1
+                },
+                "rate": {
+                    "title": "Max Rate",
+                    "step": 1,
+                    "min": 0,
+                    "max": 1000,
+                    "default": 670
+                },
+                "rc_expo": {
+                    "title": "Expo",
+                    "step": 1,
+                    "min": 0,
+                    "max": 100,
+                    "default": 70
+                }
+            }
+        }
+    }
+
+    generateRateTableGroup()
+    generateRateTableGroup('actual')
+
     if (urlParams.get('api') == 1 || urlParams.get('api') == 2) {
         config.api_version = parseInt(urlParams.get('api'));
     }


### PR DESCRIPTION
## ⚠️ WARNING: Experimental Feature — Use at Your Own Risk

This PR introduces **experimental** support for iNav rate conversions(#2).

The implementation is based on a **community-sourced Desmos calculator** shared on Reddit by [u/Antiflash1](https://www.reddit.com/user/Antiflash1/). I’ve done my best to match the formulas, but I've never personally flown iNav so **nothing has been verified against real-world behavior**.


## Feedback Needed

If you fly iNav or have any experience with its rate system, please, **I need your help**!

* Try the rate converter using iNav as source/target
* Compare results to the rates you use on other fcs
* Comment or <a href="mailto:xmarcandersonx+rate-converter@gmail.com">email me</a>.
    * dont assume others will message me, they probably won't 😢
    * i want to hear **your** feedback so i can improve the tool


## References

* **Issue:** [#2 – INAV Rates Conversion](https://github.com/Marc-Anderson/multirotor-rate-converter/issues/2)
* **Reddit Thread:** [Updated Graphing Calculator – Added INAV Rates](https://www.reddit.com/r/Multicopter/comments/1isj05g/updated_graphing_calculator_added_inav_rates/)
* **Desmos Calculator:** [https://www.desmos.com/calculator/7ph8s3vbhp](https://www.desmos.com/calculator/7ph8s3vbhp)


## Testing iNav Support


* The iNav option is **hidden behind a feature flag** and will not appear by default.
* To enable it, append `?inav=1` to the URL or use the link below
    ➡️ [https://rates.metamarc.com/?inav=1](https://rates.metamarc.com/?inav=1)
* Once enabled, **`iNavFlight`** will appear in the rate profile selector.
* You can then choose it as a source or target profile for conversions like any other rate type.


<img width="916" height="864" alt="image" src="https://github.com/user-attachments/assets/890ae125-d25d-4362-9bce-c7217cc95904" />
